### PR TITLE
Remove unnecesary update notification

### DIFF
--- a/src/core/remixes/private/RMXVariable.m
+++ b/src/core/remixes/private/RMXVariable.m
@@ -64,8 +64,6 @@
 - (void)setSelectedValue:(id)selectedValue {
   _selectedValue = selectedValue;
   [self executeUpdateBlocks];
-  [[NSNotificationCenter defaultCenter] postNotificationName:RMXVariableUpdateNotification
-                                                      object:self];
 }
 
 - (void)save {


### PR DESCRIPTION
This was causing issues with the slider. The notification should only be triggered when the update comes from the backend (in |updateToStoredVariable|).
