### PR TITLE
Fix for updating the cell when limitedToValues changes

### DIFF
--- a/src/core/RMXRemixer.m
+++ b/src/core/RMXRemixer.m
@@ -191,8 +191,6 @@
   // TODO(chuga): Improve this check for equality.
   if (![variable.selectedValue isEqual:value]) {
     [variable setSelectedValue:value];
-    [[NSNotificationCenter defaultCenter] postNotificationName:RMXVariableUpdateNotification
-                                                        object:variable];
     [[[self sharedInstance] storage] saveSelectedValueOfVariable:variable];
   }
 }

--- a/src/core/remixes/private/RMXVariable.m
+++ b/src/core/remixes/private/RMXVariable.m
@@ -64,7 +64,13 @@
 
 - (void)setSelectedValue:(id)selectedValue {
   _selectedValue = selectedValue;
+  [self triggerCellUpdateNotification];
   [self executeUpdateBlocks];
+}
+
+- (void)setLimitedToValues:(NSArray<id> *)limitedToValues {
+  _limitedToValues = limitedToValues;
+  [self triggerCellUpdateNotification];
 }
 
 - (void)save {
@@ -96,6 +102,11 @@
 
 - (NSString *)sanitizeKey:(NSString *)key {
   return [key stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+}
+
+- (void)triggerCellUpdateNotification {
+  [[NSNotificationCenter defaultCenter] postNotificationName:RMXVariableUpdateNotification
+                                                      object:self];
 }
 
 @end


### PR DESCRIPTION
Only the Variable knows when its properties change, so it should be the variable itself the one triggering the notification that we might need to reload the overlay.

Fixes #82 